### PR TITLE
Fix partidos filter query handling

### DIFF
--- a/public/panel-general.html
+++ b/public/panel-general.html
@@ -331,7 +331,7 @@ function buildQueryParams({ tracking, id_venta, cliente, desde, hasta, estado, p
   if (cliente)  p.set('cliente', cliente);
   if (!tracking) { if (desde) p.set('desde', desde); if (hasta) p.set('hasta', hasta); }
   if (estado) p.set('estado', estado);
-  if (Array.isArray(partidos) && partidos.length) partidos.forEach(n => p.append('partido', n));
+  if (Array.isArray(partidos) && partidos.length) p.set('partidos', partidos.join(','));
   if (cursor && !tracking) p.set('cursor', cursor);
   p.set('limit', String(limit)); p.set('ts', String(Date.now()));
   return p;
@@ -450,6 +450,7 @@ async function aplicarFiltro(){
   try{
     filtrosActivos={ cliente:cliRaw.trim()||undefined, tracking:tracking||undefined, id_venta:id_venta||undefined, desde:desde||undefined, hasta:hasta||undefined, estado:estado||undefined, partidos:partidos, limit:100 };
     const q=buildQueryParams(filtrosActivos);
+    console.log('Query partidos:', q.toString());
     const res=await fetch(`/api/envios?${q.toString()}`,{cache:'no-store'}); const data=await res.json();
     enviosCargados=data.rows||data||[]; nextCursor=data.nextCursor||null;
     renderTabla(); renderPaginacionLikeCursor();

--- a/routes/envios.js
+++ b/routes/envios.js
@@ -39,11 +39,34 @@ const TIME_FIELD = 'fecha'; // usamos "fecha" para ventana/sort/cursor
 
 function buildFiltroList(req) {
   const f = {};
-  const { sender_id, estado, partido, tracking, id_venta, desde, hasta } = req.query;
+  const { sender_id, estado, tracking, id_venta, desde, hasta } = req.query;
+  const partidosRaw = req.query.partidos;
+  const partidoRaw = req.query.partido;
 
   if (sender_id) f.sender_id = sender_id;
   if (estado)     f.estado    = estado;
-  if (partido)    f.partido   = partido;
+
+  const partidosList = [];
+  if (typeof partidosRaw === 'string' && partidosRaw.trim()) {
+    partidosRaw.split(',').forEach(n => {
+      const nombre = n.trim();
+      if (nombre) partidosList.push(nombre);
+    });
+  } else if (Array.isArray(partidoRaw)) {
+    partidoRaw.forEach(n => {
+      const nombre = String(n || '').trim();
+      if (nombre) partidosList.push(nombre);
+    });
+  } else if (partidoRaw) {
+    const nombre = String(partidoRaw).trim();
+    if (nombre) partidosList.push(nombre);
+  }
+
+  if (partidosList.length === 1) {
+    f.partido = partidosList[0];
+  } else if (partidosList.length > 1) {
+    f.partido = { $in: partidosList };
+  }
   if (id_venta)   f.id_venta  = id_venta;
 
   // Si buscan por tracking, NO limite de fecha


### PR DESCRIPTION
## Summary
- send selected partidos as a comma-separated query string in the panel general filter
- add temporary logging to inspect the partidos query
- parse the partidos query string on the envios route and support multi-select filters

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e080d7347c832e8bc2ce6aeb8aeba9