### PR TITLE
Add driver filter to shipments panel

### DIFF
--- a/controllers/choferController.js
+++ b/controllers/choferController.js
@@ -8,7 +8,11 @@ const User   = require('../models/User');
 /* ====== YA TENÍAS: listar choferes ====== */
 exports.listarChoferes = async (_req, res) => {
   try {
-    const choferes = await Chofer.find().sort('nombre');
+    const filtro = { $or: [{ activo: { $exists: false } }, { activo: true }] };
+    const choferes = await Chofer.find(filtro)
+      .select('nombre username activo')
+      .sort({ nombre: 1 })
+      .lean();
     res.json(choferes);
   } catch (err) { console.error(err); res.status(500).json({ msg: 'Error al listar choferes' }); }
 };

--- a/public/panel-general.html
+++ b/public/panel-general.html
@@ -86,7 +86,7 @@
 
   <!-- Filtros -->
   <div class="rounded-2xl border border-slate-200 dark:border-white/15 bg-white dark:bg-white/5 p-4 mb-4">
-    <div class="grid grid-cols-1 md:grid-cols-4 lg:grid-cols-7 gap-3">
+    <div class="grid grid-cols-1 md:grid-cols-4 lg:grid-cols-8 gap-3">
       <input id="filtroCliente" type="text" placeholder="Cliente, código o sender"
         class="w-full px-3 py-2 rounded-xl bg-white border border-slate-300
                dark:bg-white/10 dark:border-white/10" />
@@ -135,6 +135,12 @@
         <option value="no_entregado">No entregado</option>
         <option value="entregado">Entregado</option>
         <option value="cancelado">Cancelado</option>
+      </select>
+
+      <select id="filtroChofer"
+        class="w-full px-3 py-2 rounded-xl bg-white border border-slate-300
+               dark:bg-white/10 dark:border-white/10">
+        <option value="">— Todos los choferes —</option>
       </select>
 
       <button onclick="aplicarFiltro()"
@@ -324,13 +330,14 @@ let enviosCargados = []; let nextCursor = null; let filtrosActivos = {}; let map
 const normalize = s => (s || '').toString().toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '').trim();
 const cleanZona = z => (z || '').replace(/\s+(N|S|E|O|NE|NO|SE|SO)$/i, '').trim();
 
-function buildQueryParams({ tracking, id_venta, cliente, desde, hasta, estado, partidos, cursor, limit=100 }) {
+function buildQueryParams({ tracking, id_venta, cliente, desde, hasta, estado, partidos, chofer, cursor, limit=100 }) {
   const p = new URLSearchParams();
   if (tracking) p.set('tracking', tracking);
   if (id_venta) p.set('id_venta', id_venta);
   if (cliente)  p.set('cliente', cliente);
   if (!tracking) { if (desde) p.set('desde', desde); if (hasta) p.set('hasta', hasta); }
   if (estado) p.set('estado', estado);
+  if (chofer) p.set('chofer', chofer);
   if (Array.isArray(partidos) && partidos.length) p.set('partidos', partidos.join(','));
   if (cursor && !tracking) p.set('cursor', cursor);
   p.set('limit', String(limit)); p.set('ts', String(Date.now()));
@@ -417,6 +424,26 @@ function uiStatus(envio){
   return { key:norm, label:cardLabel, substatus:chip };
 }
 
+async function cargarChoferes(){
+  try{
+    const res = await fetch('/api/choferes', { cache: 'no-store' });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const choferes = await res.json();
+    const sel = document.getElementById('filtroChofer');
+    if (!sel) return;
+    sel.innerHTML = '<option value="">— Todos los choferes —</option>';
+    choferes
+      .slice()
+      .sort((a,b)=> (a?.nombre||'').localeCompare(b?.nombre||''))
+      .forEach(c=>{
+        const opt = document.createElement('option');
+        opt.value = c._id;
+        opt.textContent = c.nombre || c.username || c._id;
+        sel.appendChild(opt);
+      });
+  }catch(e){ console.error('Error cargando choferes:', e); }
+}
+
 async function cargarPartidos(){
   try{
     const res=await fetch('/api/partidos',{cache:'no-store'}); const lista=await res.json();
@@ -443,12 +470,13 @@ async function aplicarFiltro(){
   const desde=(document.getElementById('filtroDesde')?.value||'');
   const hasta=(document.getElementById('filtroHasta')?.value||'');
   const estadoSel=(document.getElementById('filtroEstado')?.value||'').toLowerCase();
+  const choferSel=(document.getElementById('filtroChofer')?.value||'');
   const tracking=trackingRaw.trim(); const id_venta=idVentaRaw.trim(); const estado=estadoSel||'';
   const partidos=[]; document.querySelectorAll('#panelPartidos input[type="checkbox"][data-nombre-norm]:checked').forEach(cb=>partidos.push(cb.getAttribute('data-nombre')));
   const all=document.getElementById('chk_all_partidos'); if(all && all.checked) partidos.length=0;
 
   try{
-    filtrosActivos={ cliente:cliRaw.trim()||undefined, tracking:tracking||undefined, id_venta:id_venta||undefined, desde:desde||undefined, hasta:hasta||undefined, estado:estado||undefined, partidos:partidos, limit:100 };
+    filtrosActivos={ cliente:cliRaw.trim()||undefined, tracking:tracking||undefined, id_venta:id_venta||undefined, desde:desde||undefined, hasta:hasta||undefined, estado:estado||undefined, chofer:choferSel||undefined, partidos:partidos, limit:100 };
     const q=buildQueryParams(filtrosActivos);
     console.log('Query partidos:', q.toString());
     const res=await fetch(`/api/envios?${q.toString()}`,{cache:'no-store'}); const data=await res.json();
@@ -464,6 +492,7 @@ async function limpiarFiltros(){
   document.getElementById('filtroDesde').value='';
   document.getElementById('filtroHasta').value='';
   document.getElementById('filtroEstado').value='';
+  const choferSel=document.getElementById('filtroChofer'); if(choferSel) choferSel.value='';
   seleccionPartidos.clear(); const all=document.getElementById('chk_all_partidos'); if(all) all.checked=true;
   document.querySelectorAll('#panelPartidos input[type="checkbox"][data-nombre-norm]').forEach(cb=>cb.checked=false);
   updateCountPartidos(); await cargarPrimerPagina();
@@ -677,7 +706,9 @@ document.addEventListener('DOMContentLoaded',()=>{
   document.getElementById('modalDetalle').addEventListener('click',(e)=>{ if(e.target===e.currentTarget) cerrarModalDetalle(); });
   document.getElementById('modalEliminar').addEventListener('click',(e)=>{ if(e.target===e.currentTarget) cerrarModalEliminar(); });
   document.addEventListener('keydown',(e)=>{ if(e.key==='Escape'){ cerrarModalDetalle(); cerrarModalEliminar(); } });
-  cargarResumenDiario(); cargarPartidos().then(()=>cargarPrimerPagina());
+  cargarResumenDiario();
+  cargarChoferes();
+  cargarPartidos().then(()=>cargarPrimerPagina());
 });
 
 async function forceSyncMeli(meli_id){

--- a/routes/envios.js
+++ b/routes/envios.js
@@ -39,12 +39,32 @@ const TIME_FIELD = 'fecha'; // usamos "fecha" para ventana/sort/cursor
 
 function buildFiltroList(req) {
   const f = {};
-  const { sender_id, estado, tracking, id_venta, desde, hasta } = req.query;
+  const { sender_id, estado, tracking, id_venta, desde, hasta, chofer } = req.query;
   const partidosRaw = req.query.partidos;
   const partidoRaw = req.query.partido;
 
   if (sender_id) f.sender_id = sender_id;
   if (estado)     f.estado    = estado;
+
+  if (chofer) {
+    const choferId = String(chofer).trim();
+    if (choferId) {
+      const conds = [];
+      if (mongoose.isValidObjectId(choferId)) {
+        const oid = new mongoose.Types.ObjectId(choferId);
+        conds.push({ chofer: oid });
+        conds.push({ chofer_id: oid });
+      }
+      conds.push({ chofer: choferId });
+      conds.push({ chofer_id: choferId });
+      conds.push({ 'chofer._id': choferId });
+      const cond = conds.length > 1 ? { $or: conds } : conds[0];
+      if (cond) {
+        if (f.$and) f.$and.push(cond);
+        else f.$and = [cond];
+      }
+    }
+  }
 
   const partidosList = [];
   if (typeof partidosRaw === 'string' && partidosRaw.trim()) {


### PR DESCRIPTION
## Summary
- add a driver filter dropdown to the shipments panel and load options from the API
- include the driver parameter in filter application and reset logic on the frontend
- expose active drivers via /api/choferes and allow filtering envios by driver id

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0822f25a8832eb3a19615e9dcb660