### PR TITLE
Add ZonaRack model and API routes

### DIFF
--- a/models/ZonaRack.js
+++ b/models/ZonaRack.js
@@ -1,0 +1,11 @@
+const mongoose = require('mongoose');
+
+const zonaRackSchema = new mongoose.Schema({
+  nombre: { type: String, required: true },
+  partidos: [{ type: String }],
+  activo: { type: Boolean, default: true },
+  orden: { type: Number, default: 0 },
+  createdAt: { type: Date, default: Date.now }
+});
+
+module.exports = mongoose.model('ZonaRack', zonaRackSchema);

--- a/routes/zonasRack.js
+++ b/routes/zonasRack.js
@@ -1,0 +1,91 @@
+const express = require('express');
+const router = express.Router();
+const ZonaRack = require('../models/ZonaRack');
+const Envio = require('../models/Envio');
+
+// GET todas las zonas configuradas
+router.get('/', async (req, res) => {
+  try {
+    const zonas = await ZonaRack.find({ activo: true }).sort({ orden: 1 });
+    res.json(zonas);
+  } catch (e) {
+    res.status(500).json({ error: e.message });
+  }
+});
+
+// POST crear/actualizar zona
+router.post('/', async (req, res) => {
+  try {
+    const { _id, nombre, partidos, orden } = req.body;
+
+    const partidosUsados = await ZonaRack.find({
+      _id: { $ne: _id },
+      partidos: { $in: partidos }
+    });
+
+    if (partidosUsados.length > 0) {
+      return res.status(400).json({
+        error: 'Partidos ya asignados',
+        conflicto: partidosUsados[0].nombre
+      });
+    }
+
+    if (_id) {
+      const zona = await ZonaRack.findByIdAndUpdate(
+        _id,
+        { nombre, partidos, orden },
+        { new: true }
+      );
+      res.json(zona);
+    } else {
+      const zona = await ZonaRack.create({ nombre, partidos, orden });
+      res.json(zona);
+    }
+  } catch (e) {
+    res.status(500).json({ error: e.message });
+  }
+});
+
+// DELETE eliminar zona
+router.delete('/:id', async (req, res) => {
+  try {
+    await ZonaRack.findByIdAndUpdate(req.params.id, { activo: false });
+    res.json({ ok: true });
+  } catch (e) {
+    res.status(500).json({ error: e.message });
+  }
+});
+
+// GET KPIs de una zona específica (13hs ayer → 13hs hoy)
+router.get('/:id/kpi', async (req, res) => {
+  try {
+    const zona = await ZonaRack.findById(req.params.id);
+    if (!zona) return res.status(404).json({ error: 'Zona no encontrada' });
+
+    const now = new Date();
+    const ayer13hs = new Date(now);
+    ayer13hs.setDate(ayer13hs.getDate() - 1);
+    ayer13hs.setHours(13, 0, 0, 0);
+
+    const hoy13hs = new Date(now);
+    hoy13hs.setHours(13, 0, 0, 0);
+
+    const filtro = {
+      partido: { $in: zona.partidos },
+      estado: { $in: ['pendiente', 'en_camino'] },
+      fecha: { $gte: ayer13hs, $lte: hoy13hs }
+    };
+
+    const [pendientes, en_camino, total] = await Promise.all([
+      Envio.countDocuments({ ...filtro, estado: 'pendiente' }),
+      Envio.countDocuments({ ...filtro, estado: 'en_camino' }),
+      Envio.countDocuments(filtro)
+    ]);
+
+    res.json({ pendientes, en_camino, total });
+  } catch (e) {
+    res.status(500).json({ error: e.message });
+  }
+});
+
+module.exports = router;

--- a/server.js
+++ b/server.js
@@ -170,6 +170,7 @@ for (const [route, file] of Object.entries(pages)) {
 
 /* -------------- A partir de acá, todo requiere sesión ---------------- */
 app.use('/api/zonas',            require('./routes/zonas'));
+app.use('/api/zonas-rack',       require('./routes/zonasRack'));
 app.use('/api/listas-de-precios',require('./routes/listasDePrecios'));
 app.use('/api/partidos',         require('./routes/partidos'));
 app.use('/api/clientes',         require('./routes/clientes'));


### PR DESCRIPTION
## Summary
- add ZonaRack mongoose model to manage rack zone definitions
- implement CRUD and KPI endpoints for rack zones
- register new rack zone routes in the Express server

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0894f9e44832eb293f45b59bd21f1