### PR TITLE
Add rack zone status view switch

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -108,7 +108,23 @@
   <section class="mb-6">
     <div class="rounded-2xl border border-slate-200 dark:border-white/10 bg-white dark:bg-white/5 p-4">
       <div class="flex items-center justify-between mb-4">
-        <h3 class="text-lg font-semibold">Zonas de Rack (13hs ayer → 13hs hoy)</h3>
+        <div class="flex items-center gap-4">
+          <h3 class="text-lg font-semibold">Zonas de Rack</h3>
+
+          <!-- Switch de vista -->
+          <div class="flex items-center gap-2 bg-slate-100 dark:bg-white/5 rounded-xl p-1">
+            <button id="btnVistaPendientes"
+              onclick="cambiarVistaRack('pendiente')"
+              class="px-3 py-1.5 rounded-lg text-sm font-medium bg-white dark:bg-white/10 shadow">
+              Pendientes
+            </button>
+            <button id="btnVistaEnCamino"
+              onclick="cambiarVistaRack('en_camino')"
+              class="px-3 py-1.5 rounded-lg text-sm font-medium">
+              En Camino
+            </button>
+          </div>
+        </div>
         <button onclick="abrirConfigZonas()"
           class="px-3 py-1.5 text-sm rounded-xl border border-slate-300 hover:bg-slate-50 dark:border-white/10 dark:hover:bg-white/10">
           ⚙️ Configurar zonas
@@ -296,6 +312,29 @@
   let partidosDisponibles = [];
   let partidosAsignados = new Set();
   let kpiRackIntervalId = null;
+  let vistaRackActual = 'pendiente'; // 'pendiente' o 'en_camino'
+
+  function cambiarVistaRack(vista) {
+    vistaRackActual = vista;
+
+    // Actualizar estilos de botones
+    const btnPend = document.getElementById('btnVistaPendientes');
+    const btnRuta = document.getElementById('btnVistaEnCamino');
+
+    if (!btnPend || !btnRuta) return;
+
+    if (vista === 'pendiente') {
+      btnPend.classList.add('bg-white', 'dark:bg-white/10', 'shadow');
+      btnRuta.classList.remove('bg-white', 'dark:bg-white/10', 'shadow');
+    } else {
+      btnRuta.classList.add('bg-white', 'dark:bg-white/10', 'shadow');
+      btnPend.classList.remove('bg-white', 'dark:bg-white/10', 'shadow');
+    }
+
+    actualizarColoresKPIs();
+    // Refrescar todas las cajas con el nuevo estado
+    actualizarKPIsRack();
+  }
 
   function recalcularPartidosAsignados() {
     partidosAsignados = new Set(zonasRack.flatMap(z => z.partidos || []));
@@ -349,7 +388,7 @@
       return `
         <div class="rounded-xl p-3 border border-slate-200 dark:border-white/10 bg-slate-50 dark:bg-white/5">
           <div class="text-xs font-medium opacity-70 truncate" title="${nombre}">${nombre}</div>
-          <div id="kpi-rack-${zonaId}" class="text-2xl font-semibold mt-1 text-indigo-600 dark:text-indigo-400">—</div>
+          <div id="kpi-rack-${zonaId}" class="text-2xl font-semibold mt-1">—</div>
           <div id="kpi-rack-detalle-${zonaId}" class="text-[10px] opacity-60 mt-1">Cargando...</div>
         </div>
       `;
@@ -366,18 +405,39 @@
       const zonaId = zona && (zona._id || zona.id);
       if (zonaId) cargarKPIZona(zonaId);
     });
+    actualizarColoresKPIs();
+  }
+
+  function actualizarColoresKPIs() {
+    const colorClass = vistaRackActual === 'pendiente'
+      ? 'text-amber-600 dark:text-amber-400'
+      : 'text-sky-600 dark:text-sky-400';
+
+    zonasRack.forEach(zona => {
+      const zonaId = zona && (zona._id || zona.id);
+      if (!zonaId) return;
+      const el = document.getElementById(`kpi-rack-${zonaId}`);
+      if (el) {
+        el.className = `text-2xl font-semibold mt-1 ${colorClass}`;
+      }
+    });
   }
 
   async function cargarKPIZona(zonaId) {
     try {
-      const r = await fetch(`/api/zonas-rack/${zonaId}/kpi`, { cache: 'no-store' });
+      const r = await fetch(`/api/zonas-rack/${zonaId}/kpi?estado=${vistaRackActual}`, {
+        cache: 'no-store'
+      });
       if (!r.ok) throw new Error(`HTTP ${r.status}`);
       const data = await r.json();
 
       const totalEl = document.getElementById(`kpi-rack-${zonaId}`);
       const detalleEl = document.getElementById(`kpi-rack-detalle-${zonaId}`);
       if (totalEl) totalEl.textContent = data.total ?? '0';
-      if (detalleEl) detalleEl.textContent = `P:${data.pendientes ?? 0} | R:${data.en_camino ?? 0}`;
+      if (detalleEl) {
+        const label = vistaRackActual === 'pendiente' ? 'Pendientes' : 'En ruta';
+        detalleEl.textContent = `${label}: ${data.total ?? 0}`;
+      }
     } catch (e) {
       console.error('Error KPI zona:', zonaId, e);
     }


### PR DESCRIPTION
## Summary
- add a UI switch to toggle rack zone KPIs between pendientes and en camino views
- request rack KPI data using the selected estado and update color coding accordingly
- adjust the zonas rack KPI endpoint to require an estado filter and remove the time window restriction

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e499a5c52c832e851f8dbebab3afb5