### PR TITLE
Fix dark mode dropdown backgrounds in general panel

### DIFF
--- a/public/panel-general.html
+++ b/public/panel-general.html
@@ -31,6 +31,39 @@
     --z-primary-dark:#D97706;  /* hover */
     --z-primary-fg:#111827;    /* texto sobre ámbar */
   }
+
+  /* Fix para dropdowns en dark mode */
+  html.dark select,
+  html.dark select option {
+    background-color:#0B1020;
+    color:#e5e7eb;
+    border-color:rgba(255,255,255,0.1);
+  }
+
+  html.dark select option:hover,
+  html.dark select option:focus,
+  html.dark select option:checked {
+    background-color:#1e293b;
+    color:#fff;
+  }
+
+  /* Fondo del dropdown cuando está abierto */
+  html.dark select:focus {
+    background-color:#0B1020;
+    outline-color:#F59E0B;
+  }
+
+  /* Inputs de fecha también */
+  html.dark input[type="date"] {
+    background-color:#0B1020;
+    color:#e5e7eb;
+    border-color:rgba(255,255,255,0.1);
+  }
+
+  html.dark input[type="date"]::-webkit-calendar-picker-indicator {
+    filter:invert(1) opacity(0.7);
+  }
+
   /* Dropdown de Partidos en dark */
   #panelPartidos{ backdrop-filter:saturate(120%) blur(6px); }
 </style>
@@ -140,14 +173,13 @@
       </div>
 
       <select id="filtroEstado"
-        class="w-full px-3 py-2 rounded-xl bg-white border border-slate-300
-               dark:bg-white/10 dark:border-white/10">
+        class="w-full px-3 py-2 rounded-xl bg-white border border-slate-300 dark:bg-[#0B1020] dark:border-white/10 dark:text-slate-100">
         <option value="">— Todos los estados —</option>
         <option value="pendiente">Pendiente</option>
         <option value="asignado">Asignado</option>
         <option value="en_camino">En camino</option>
 
-        <optgroup label="Problemas de entrega">
+        <optgroup label="Problemas de entrega" class="dark:bg-[#1e293b]">
           <option value="comprador_ausente">Comprador ausente</option>
           <option value="inaccesible">Inaccesible/Avería</option>
           <option value="direccion_erronea">Dirección errónea</option>
@@ -162,8 +194,7 @@
       </select>
 
       <select id="filtroChofer"
-        class="w-full px-3 py-2 rounded-xl bg-white border border-slate-300
-               dark:bg-white/10 dark:border-white/10">
+        class="w-full px-3 py-2 rounded-xl bg-white border border-slate-300 dark:bg-[#0B1020] dark:border-white/10 dark:text-slate-100">
         <option value="">— Todos los choferes —</option>
       </select>
 


### PR DESCRIPTION
## Summary
- add dark mode styling so select elements and their options display correctly
- adjust filter dropdown and date picker styles to match the dark theme

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5c986378c832e8a6e22c1858ed097